### PR TITLE
[feat] ignore command, merge erase에 대한 최적화 전략 구현 1

### DIFF
--- a/ssd_core/discovery_buffer_optimizer.py
+++ b/ssd_core/discovery_buffer_optimizer.py
@@ -9,6 +9,10 @@ VALUE_MARK = 2
 
 class DiscoveryBufferOptimizer(AbstractBufferOptimizer):
     def calculate(self, buffer_lst: list[Packet]) -> list[Packet]:
+        """
+        
+        """
+
         # project values
         erase_lst = self.project_erase(buffer_lst)
         write_lst = self.project_write(buffer_lst)

--- a/ssd_core/discovery_buffer_optimizer.py
+++ b/ssd_core/discovery_buffer_optimizer.py
@@ -25,7 +25,7 @@ class DiscoveryBufferOptimizer(AbstractBufferOptimizer):
 
 
     def project_erase(self, buffer_lst: list[Packet]) -> list[int]:
-        result = [0 * 100] # LBA 0~99
+        result = [0] * 100 # LBA 0~99
         for cmd in buffer_lst:
             if cmd.COMMAND == "E":
                 for i in range(cmd.SIZE):
@@ -33,7 +33,7 @@ class DiscoveryBufferOptimizer(AbstractBufferOptimizer):
         return result
 
     def project_write(self, buffer_lst) -> list[int]:
-        result = [0 * 100]  # LBA 0~99
+        result = [0] * 100  # LBA 0~99
         for cmd in buffer_lst:
             if cmd.COMMAND == "E":
                 for i in range(cmd.SIZE):

--- a/ssd_core/discovery_buffer_optimizer.py
+++ b/ssd_core/discovery_buffer_optimizer.py
@@ -1,0 +1,43 @@
+import copy
+from itertools import product
+from ssd_core.abstract_buffer_optimizer import AbstractBufferOptimizer
+from validator import Packet
+
+VALUE_EMPTY = 0
+VALUE_VALID = 1
+VALUE_MARK = 2
+
+class DiscoveryBufferOptimizer(AbstractBufferOptimizer):
+    def calculate(self, buffer_lst: list[Packet]) -> list[Packet]:
+        # project values
+        erase_lst = self.project_erase(buffer_lst)
+        write_lst = self.project_write(buffer_lst)
+        check_lst = [i for i, val in enumerate(erase_lst) if val == VALUE_MARK]
+
+        # iteration
+
+        # find best
+
+        # compare
+
+        # return
+        return buffer_lst
+
+
+    def project_erase(self, buffer_lst: list[Packet]) -> list[int]:
+        result = [0 * 100] # LBA 0~99
+        for cmd in buffer_lst:
+            if cmd.COMMAND == "E":
+                for i in range(cmd.SIZE):
+                    result[cmd.ADDR + i] = VALUE_VALID
+        return result
+
+    def project_write(self, buffer_lst) -> list[int]:
+        result = [0 * 100]  # LBA 0~99
+        for cmd in buffer_lst:
+            if cmd.COMMAND == "E":
+                for i in range(cmd.SIZE):
+                    result[cmd.ADDR + i] = VALUE_EMPTY # overwrite
+            elif cmd.COMMAND == "W":
+                result[cmd.ADDR] = VALUE_VALID # written
+        return result

--- a/ssd_core/discovery_buffer_optimizer.py
+++ b/ssd_core/discovery_buffer_optimizer.py
@@ -1,54 +1,150 @@
 import copy
-from itertools import product
+from itertools import product, combinations
 from ssd_core.abstract_buffer_optimizer import AbstractBufferOptimizer
 from validator import Packet
 
 VALUE_EMPTY = 0
 VALUE_VALID = 1
-VALUE_MARK = 2
+
 
 class DiscoveryBufferOptimizer(AbstractBufferOptimizer):
     def calculate(self, buffer_lst: list[Packet]) -> list[Packet]:
-        """
-        plan
-        - erase 영역을 모두 모은다
-        - write 영역을 모두 모은다. erase가 덮어쓰는 경우는 제외 한다.
-        - erase 이후에 write 되는 erase 영역을 mark 영역으로 정의하고 마킹한다.
-        - mark 영역에 erase를 수행할지 말지를 0/1로 구분하여 경우의 수를 생성한다.
-        - 경우의 수는 erase 1번 write 4번인 경우 2^4 = 16개가 생성된다.
-        - 16개의 erase 경우에 수에 대해, 최소로 erase 하는 카운트 + write 카운트가 최적해가 된다. (라고 믿고 싶다)
-        - erase를 최소로 하는 카운트는 greedy로 순차 선택하여도 최적해가 나온다. (고 밑고 있다)
-        - 순회 하는 중,  current_count와 동률이 나올 경우 skip 후 다음 해를 시도 한다.
-        """
-        # project values
-        erase_lst = self.project_erase(buffer_lst)
-        write_lst = self.project_write(buffer_lst)
-        check_lst = [i for i, val in enumerate(erase_lst) if val == VALUE_MARK]
+        print()
+        # trivial case
+        if len(buffer_lst) == 0 or len(buffer_lst) == 1:
+            return buffer_lst
 
-        # iteration
+        # '0'으로 write하는 명령은 erase 명령으로 교체한다.
+        replaced_buffer_lst = self.replace_zero_write(buffer_lst)
 
-        # find best
+        # erase 영역을 모은다.
+        erase_mask = self.project_erase(replaced_buffer_lst)
+        self.print_format("ERASE_MASK", erase_mask)
 
-        # compare
+        # write 영역을 모은다.
+        write_mask, write_value = self.project_write(replaced_buffer_lst)
+        self.print_format("WRITE_MASK", write_mask)
 
-        # return
-        return buffer_lst
+        # erase, write mask를 합친다.
+        merged_mask = self.merge_erase_and_write(erase_mask, write_mask)
+        self.print_format("MERGED_MASK", merged_mask)
 
+        # write에 의해 overwrite 되는 erase 영역을 찾는다.
+        overwritten_idx = [i for i, x in enumerate(write_mask) if x == VALUE_VALID]
+        self.print_format("OVER_WRITTEN_IDX", overwritten_idx, lst_seperator=',')
+
+        best_erase_mask = erase_mask
+        best_erase_cmd_lst = [cmd for cmd in replaced_buffer_lst if cmd.COMMAND == "E"]
+        best_write_cmd_lst = [Packet(COMMAND="W", ADDR=i, VALUE=pkt[1])
+                              for i, pkt in enumerate(zip(write_mask, write_value))
+                              if pkt[0] == VALUE_VALID]
+
+        # overwrite 영역은 erase 해도 되고 안해도 된다.
+        # overwrite 영역을 하나씩 선택 하면서, 최소 erase 횟수를 찾는다.
+        try_cnt = 1
+        for r in range(0, len(overwritten_idx) + 1):
+            for selected_element in combinations(overwritten_idx, r):
+                next_erase_mask = merged_mask.copy()
+                for idx in selected_element:
+                    next_erase_mask[idx] = VALUE_EMPTY
+
+                current_erase_cmd_cnt = 0
+                counting = False
+                counting_cnt = 0
+                current_erase_cmd_lst = []
+                erase_cmd_new = None
+                for i, value in enumerate(next_erase_mask):
+                    if value == VALUE_VALID:
+                        if not counting:
+                            counting = True
+                            counting_cnt = 1
+                            erase_cmd_new = Packet(COMMAND="E", ADDR=i)
+                        else:
+                            if counting_cnt == 9:
+                                current_erase_cmd_cnt += 1
+                                erase_cmd_new.SIZE = 10
+                                current_erase_cmd_lst.append(erase_cmd_new)
+                                erase_cmd_new = None
+                                counting = False
+                                counting_cnt = 0
+                            else:
+                                counting_cnt += 1
+                    elif value == VALUE_EMPTY:
+                        if counting:
+                            current_erase_cmd_cnt += 1
+                            erase_cmd_new.SIZE = counting_cnt
+                            current_erase_cmd_lst.append(erase_cmd_new)
+                            erase_cmd_new = None
+                            counting = False
+                            counting_cnt = 0
+
+                if current_erase_cmd_cnt < len(best_erase_cmd_lst):
+                    best_erase_mask = next_erase_mask
+                    best_erase_cmd_lst = current_erase_cmd_lst
+
+                try_cnt += 1
+                self.print_format(f"#{try_cnt:>3},r={r},selected={selected_element},"
+                                  f"result={current_erase_cmd_cnt},best={len(best_erase_cmd_lst)}",
+                                  next_erase_mask)
+
+                # 최적값을 찾은 경우 탐색 중단
+                #if len(best_erase_cmd_lst) <= 1:
+                #    break
+
+        self.print_format("ERASE_MASK", erase_mask)
+        self.print_format("FINAL_ERASE_BEST", best_erase_mask)
+        self.print_format("WRITE_MASK", write_mask)
+        self.print_format("MERGED_MASK", merged_mask)
+
+        # validate
+        # 2. 기존과 길이가 같은 경우, 기존 명령셋을 그대로 리턴한다.
+        # 3. e 명령어 lba 범위, 길이 체크, w 명령어 lba 범위 체크, 값 0 아닌지 체크
+
+        print(f"INPUT CMD(ORG),{len(buffer_lst)}={buffer_lst}")
+        final_cmd_lst = best_erase_cmd_lst + best_write_cmd_lst
+        if len(final_cmd_lst) < len(buffer_lst):
+            print(f"FINAL CMD(OPT),{len(final_cmd_lst)}={final_cmd_lst}")
+            return final_cmd_lst
+        else:
+            print(f"FINAL CMD(ORG),{len(buffer_lst)}={buffer_lst}")
+            return buffer_lst
+
+    def replace_zero_write(self, buffer_lst: list[Packet]) -> list[Packet]:
+        new_lst = []
+        for item in buffer_lst:
+            if item.COMMAND == "W" and item.VALUE == 0:
+                new_lst.append(Packet(COMMAND="E", ADDR=item.ADDR, SIZE=1))
+            else:
+                new_lst.append(item)
+        return new_lst
 
     def project_erase(self, buffer_lst: list[Packet]) -> list[int]:
-        result = [0] * 100 # LBA 0~99
+        mask = [0] * 100  # LBA 0~99
         for cmd in buffer_lst:
             if cmd.COMMAND == "E":
                 for i in range(cmd.SIZE):
-                    result[cmd.ADDR + i] = VALUE_VALID
-        return result
+                    mask[cmd.ADDR + i] = VALUE_VALID
+        return mask
 
-    def project_write(self, buffer_lst) -> list[int]:
-        result = [0] * 100  # LBA 0~99
+    def project_write(self, buffer_lst) -> (list[int], list[int]):
+        mask = [0] * 100  # LBA 0~99
+        value = [0] * 100
         for cmd in buffer_lst:
             if cmd.COMMAND == "E":
                 for i in range(cmd.SIZE):
-                    result[cmd.ADDR + i] = VALUE_EMPTY # overwrite
+                    mask[cmd.ADDR + i] = VALUE_EMPTY  # overwrite
             elif cmd.COMMAND == "W":
-                result[cmd.ADDR] = VALUE_VALID # written
-        return result
+                mask[cmd.ADDR] = VALUE_VALID  # written
+                value[cmd.ADDR] = cmd.VALUE
+        return mask, value
+
+    def merge_erase_and_write(self, erase_lst, write_lst) -> list[int]:
+        mask = erase_lst.copy()
+        for i in range(len(write_lst)):
+            if write_lst[i] == VALUE_VALID:
+                mask[i] = VALUE_VALID
+
+        return mask
+
+    def print_format(self, prefix, lst, lst_seperator=''):
+        print(f"{prefix:>50} [{lst_seperator.join(map(str, lst))}]")

--- a/ssd_core/discovery_buffer_optimizer.py
+++ b/ssd_core/discovery_buffer_optimizer.py
@@ -133,7 +133,7 @@ class DiscoveryBufferOptimizer(AbstractBufferOptimizer):
                     mask[cmd.ADDR + i] = VALUE_VALID
         return mask
 
-    def project_write(self, buffer_lst) -> (list[int], list[int]):
+    def project_write(self, buffer_lst) -> tuple[list[int], list[int]]:
         mask = [0] * 100  # LBA 0~99
         value = [0] * 100
         for cmd in buffer_lst:

--- a/ssd_core/discovery_buffer_optimizer.py
+++ b/ssd_core/discovery_buffer_optimizer.py
@@ -10,9 +10,16 @@ VALUE_MARK = 2
 class DiscoveryBufferOptimizer(AbstractBufferOptimizer):
     def calculate(self, buffer_lst: list[Packet]) -> list[Packet]:
         """
-        
+        plan
+        - erase 영역을 모두 모은다
+        - write 영역을 모두 모은다. erase가 덮어쓰는 경우는 제외 한다.
+        - erase 이후에 write 되는 erase 영역을 mark 영역으로 정의하고 마킹한다.
+        - mark 영역에 erase를 수행할지 말지를 0/1로 구분하여 경우의 수를 생성한다.
+        - 경우의 수는 erase 1번 write 4번인 경우 2^4 = 16개가 생성된다.
+        - 16개의 erase 경우에 수에 대해, 최소로 erase 하는 카운트 + write 카운트가 최적해가 된다. (라고 믿고 싶다)
+        - erase를 최소로 하는 카운트는 greedy로 순차 선택하여도 최적해가 나온다. (고 밑고 있다)
+        - 순회 하는 중,  current_count와 동률이 나올 경우 skip 후 다음 해를 시도 한다.
         """
-
         # project values
         erase_lst = self.project_erase(buffer_lst)
         write_lst = self.project_write(buffer_lst)

--- a/ssd_core/discovery_buffer_optimizer.py
+++ b/ssd_core/discovery_buffer_optimizer.py
@@ -3,6 +3,8 @@ from itertools import product, combinations
 from ssd_core.abstract_buffer_optimizer import AbstractBufferOptimizer
 from validator import Packet
 
+MAX_LBA_ADDRESS = 100
+
 VALUE_EMPTY = 0
 VALUE_VALID = 1
 
@@ -67,7 +69,7 @@ class DiscoveryBufferOptimizer(AbstractBufferOptimizer):
                                 erase_cmd_new = None
                                 counting = False
                                 counting_cnt = 0
-                            elif i == 99:
+                            elif i == MAX_LBA_ADDRESS - 1:
                                 current_erase_cmd_cnt += 1
                                 erase_cmd_new.SIZE = counting_cnt + 1
                                 current_erase_cmd_lst.append(erase_cmd_new)
@@ -126,7 +128,7 @@ class DiscoveryBufferOptimizer(AbstractBufferOptimizer):
         return new_lst
 
     def project_erase(self, buffer_lst: list[Packet]) -> list[int]:
-        mask = [0] * 100  # LBA 0~99
+        mask = [0] * MAX_LBA_ADDRESS  # LBA 0~99
         for cmd in buffer_lst:
             if cmd.COMMAND == "E":
                 for i in range(cmd.SIZE):
@@ -134,8 +136,8 @@ class DiscoveryBufferOptimizer(AbstractBufferOptimizer):
         return mask
 
     def project_write(self, buffer_lst) -> tuple[list[int], list[int]]:
-        mask = [0] * 100  # LBA 0~99
-        value = [0] * 100
+        mask = [0] * MAX_LBA_ADDRESS  # LBA 0~99
+        value = [0] * MAX_LBA_ADDRESS
         for cmd in buffer_lst:
             if cmd.COMMAND == "E":
                 for i in range(cmd.SIZE):

--- a/ssd_core/discovery_buffer_optimizer.py
+++ b/ssd_core/discovery_buffer_optimizer.py
@@ -67,6 +67,13 @@ class DiscoveryBufferOptimizer(AbstractBufferOptimizer):
                                 erase_cmd_new = None
                                 counting = False
                                 counting_cnt = 0
+                            elif i == 99:
+                                current_erase_cmd_cnt += 1
+                                erase_cmd_new.SIZE = counting_cnt + 1
+                                current_erase_cmd_lst.append(erase_cmd_new)
+                                erase_cmd_new = None
+                                counting = False
+                                counting_cnt = 0
                             else:
                                 counting_cnt += 1
                     elif value == VALUE_EMPTY:
@@ -101,7 +108,7 @@ class DiscoveryBufferOptimizer(AbstractBufferOptimizer):
         # 3. e 명령어 lba 범위, 길이 체크, w 명령어 lba 범위 체크, 값 0 아닌지 체크
 
         print(f"INPUT CMD(ORG),{len(buffer_lst)}={buffer_lst}")
-        final_cmd_lst = best_erase_cmd_lst + best_write_cmd_lst
+        final_cmd_lst = best_erase_cmd_lst + best_write_cmd_lst     # erase + write 순서가 유지 되어야 함.
         if len(final_cmd_lst) < len(buffer_lst):
             print(f"FINAL CMD(OPT),{len(final_cmd_lst)}={final_cmd_lst}")
             return final_cmd_lst

--- a/tests/test_discovery_buffer_optimizer.py
+++ b/tests/test_discovery_buffer_optimizer.py
@@ -359,57 +359,34 @@ def test_명령어가_1개이하인경우_최적화하지_않는다(abstract_buf
 
 @pytest.mark.parametrize("tc, expected_cmd", [
     #1. 중복 erase 제거
-    [
-        [Packet(COMMAND="E", ADDR=0, SIZE=5), Packet(COMMAND="E", ADDR=0, SIZE=5)],
-        [Packet(COMMAND="E", ADDR=0, SIZE=5)]
-    ],
-    [
-        [Packet(COMMAND="E", ADDR=10, SIZE=5), Packet(COMMAND="E", ADDR=10, SIZE=2)],
-        [Packet(COMMAND="E", ADDR=10, SIZE=5)]
-    ],
+    [[Packet(COMMAND="E", ADDR=0, SIZE=5), Packet(COMMAND="E", ADDR=0, SIZE=5)],
+     [Packet(COMMAND="E", ADDR=0, SIZE=5)]],
+    [[Packet(COMMAND="E", ADDR=10, SIZE=5), Packet(COMMAND="E", ADDR=10, SIZE=2)],
+     [Packet(COMMAND="E", ADDR=10, SIZE=5)]],
 
     # 2. 중첩, 연속 erase merge (총 길이 10 이하)
-    [
-        [Packet(COMMAND="E", ADDR=0, SIZE=5), Packet(COMMAND="E", ADDR=5, SIZE=5)],
-        [Packet(COMMAND="E", ADDR=0, SIZE=10)]
-    ],
-    [
-        [Packet(COMMAND="E", ADDR=10, SIZE=5), Packet(COMMAND="E", ADDR=10, SIZE=7)],
-        [Packet(COMMAND="E", ADDR=10, SIZE=7)]
-    ],
-    [
-        [Packet(COMMAND="E", ADDR=10, SIZE=5), Packet(COMMAND="E", ADDR=10, SIZE=7), Packet(COMMAND="E", ADDR=12, SIZE=3)],
-        [Packet(COMMAND="E", ADDR=10, SIZE=7)]
-    ],
+    [[Packet(COMMAND="E", ADDR=0, SIZE=5), Packet(COMMAND="E", ADDR=5, SIZE=5)],
+     [Packet(COMMAND="E", ADDR=0, SIZE=10)]],
+    [[Packet(COMMAND="E", ADDR=10, SIZE=5), Packet(COMMAND="E", ADDR=10, SIZE=7)],
+     [Packet(COMMAND="E", ADDR=10, SIZE=7)]],
+    [[Packet(COMMAND="E", ADDR=10, SIZE=5), Packet(COMMAND="E", ADDR=10, SIZE=7), Packet(COMMAND="E", ADDR=12, SIZE=3)],
+     [Packet(COMMAND="E", ADDR=10, SIZE=7)]],
 
     # 3. 중첩, 연속 erase merge (총 길이 10 이상)
-    [
-        [Packet(COMMAND="E", ADDR=0, SIZE=7), Packet(COMMAND="E", ADDR=7, SIZE=7), Packet(COMMAND="E", ADDR=14, SIZE=6)],
-        [Packet(COMMAND="E", ADDR=0, SIZE=10), Packet(COMMAND="E", ADDR=10, SIZE=10)]
-    ],
+    [[Packet(COMMAND="E", ADDR=0, SIZE=7), Packet(COMMAND="E", ADDR=7, SIZE=7), Packet(COMMAND="E", ADDR=14, SIZE=6)],
+     [Packet(COMMAND="E", ADDR=0, SIZE=10), Packet(COMMAND="E", ADDR=10, SIZE=10)]],
 
     # 4. erase에 의해 overwrite 되는 write 명령 제거
-    [
-        [Packet(COMMAND="W", ADDR=1, VALUE=0x1), Packet(COMMAND="W", ADDR=3, VALUE=0x3), Packet(COMMAND="W", ADDR=5, VALUE=0x5),
-         Packet(COMMAND="E", ADDR=0, SIZE=10)],
-        [Packet(COMMAND="E", ADDR=0, SIZE=10)]
-    ],
+    [[Packet(COMMAND="W", ADDR=1, VALUE=0x1), Packet(COMMAND="W", ADDR=3, VALUE=0x3), Packet(COMMAND="W", ADDR=5, VALUE=0x5), Packet(COMMAND="E", ADDR=0, SIZE=10)],
+     [Packet(COMMAND="E", ADDR=0, SIZE=10)]],
 
     # 5. erase가 write 보다 먼저 수행되는 경우 write 명령 유지
-    [
-        [Packet(COMMAND="E", ADDR=0, SIZE=10),
-        Packet(COMMAND="W", ADDR=1, VALUE=0x1), Packet(COMMAND="W", ADDR=3, VALUE=0x3), Packet(COMMAND="W", ADDR=5, VALUE=0x5)],
-        [Packet(COMMAND="E", ADDR=0, SIZE=10),
-         Packet(COMMAND="W", ADDR=1, VALUE=0x1), Packet(COMMAND="W", ADDR=3, VALUE=0x3), Packet(COMMAND="W", ADDR=5, VALUE=0x5)]
-    ],
+    [[Packet(COMMAND="E", ADDR=0, SIZE=10), Packet(COMMAND="W", ADDR=1, VALUE=0x1), Packet(COMMAND="W", ADDR=3, VALUE=0x3), Packet(COMMAND="W", ADDR=5, VALUE=0x5)],
+     [Packet(COMMAND="E", ADDR=0, SIZE=10), Packet(COMMAND="W", ADDR=1, VALUE=0x1), Packet(COMMAND="W", ADDR=3, VALUE=0x3), Packet(COMMAND="W", ADDR=5, VALUE=0x5)]],
 
     # 6. write로 덮어지는 영역이 2개 이상의 erase 영역을 접합하는 경우
-    [
-        [Packet(COMMAND="E", ADDR=0, SIZE=2), Packet(COMMAND="E", ADDR=3, SIZE=2), Packet(COMMAND="E", ADDR=6, SIZE=2),
-        Packet(COMMAND="W", ADDR=2, VALUE=0x2), Packet(COMMAND="W", ADDR=5, VALUE=0x5)],
-        [Packet(COMMAND="E", ADDR=0, SIZE=8),
-         Packet(COMMAND="W", ADDR=2, VALUE=0x2), Packet(COMMAND="W", ADDR=5, VALUE=0x5)]
-    ],
+    [[Packet(COMMAND="E", ADDR=0, SIZE=2), Packet(COMMAND="E", ADDR=3, SIZE=2), Packet(COMMAND="E", ADDR=6, SIZE=2), Packet(COMMAND="W", ADDR=2, VALUE=0x2), Packet(COMMAND="W", ADDR=5, VALUE=0x5)],
+     [Packet(COMMAND="E", ADDR=0, SIZE=8), Packet(COMMAND="W", ADDR=2, VALUE=0x2), Packet(COMMAND="W", ADDR=5, VALUE=0x5)]],
 
     # tc from SimpleBufferOptimizer
     # 1. 중복 Write 제거
@@ -471,4 +448,3 @@ def test_명령어가_1개이하인경우_최적화하지_않는다(abstract_buf
 def test_buffer_최적화_반환_커맨드_동일_케이스_검증(abstract_buffer_optimizer, tc, expected_cmd):
     result = abstract_buffer_optimizer.calculate(tc)
     assert result == expected_cmd
-

--- a/tests/test_discovery_buffer_optimizer.py
+++ b/tests/test_discovery_buffer_optimizer.py
@@ -332,3 +332,107 @@ def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_7(
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ]
+
+
+def test_W_명령값이_0_인경우_E명령으로_대체한다_1():
+    algo = DiscoveryBufferOptimizer()
+
+    tc = [
+        Packet(COMMAND="W", ADDR=3, VALUE=0),
+    ]
+
+    result = algo.replace_zero_write(tc)
+
+    assert len(result) == 1
+    assert result[0].COMMAND == "E"
+    assert result[0].ADDR == 3
+    assert result[0].SIZE == 1
+
+
+def test_W_명령값이_0_인경우_E명령으로_대체한다_2():
+    algo = DiscoveryBufferOptimizer()
+
+    tc = [
+        Packet(COMMAND="W", ADDR=1, VALUE=1),
+        Packet(COMMAND="W", ADDR=3, VALUE=0),
+        Packet(COMMAND="W", ADDR=2, VALUE=2),
+    ]
+
+    result = algo.replace_zero_write(tc)
+
+    assert len(result) == 3
+    assert result[0] == tc[0]
+    assert result[2] == tc[2]
+
+    assert result[1].COMMAND == "E"
+    assert result[1].ADDR == 3
+    assert result[1].SIZE == 1
+
+@pytest.mark.parametrize("tc", [
+    [],
+    [Packet(COMMAND="W", ADDR=0, VALUE=1)],
+    [Packet(COMMAND="E", ADDR=0, VALUE=1)],
+])
+def test_명령어가_1개이하인경우_최적화하지_않는다(optimizer, tc):
+    result = optimizer.calculate(tc)
+
+    assert result == tc
+
+
+@pytest.mark.parametrize("tc, expected_cmd", [
+    #1. 중복 erase 제거
+    [
+        [Packet(COMMAND="E", ADDR=0, SIZE=5), Packet(COMMAND="E", ADDR=0, SIZE=5)],
+        [Packet(COMMAND="E", ADDR=0, SIZE=5)]
+    ],
+    [
+        [Packet(COMMAND="E", ADDR=10, SIZE=5), Packet(COMMAND="E", ADDR=10, SIZE=2)],
+        [Packet(COMMAND="E", ADDR=10, SIZE=5)]
+    ],
+
+    # 2. 중첩, 연속 erase merge (총 길이 10 이하)
+    [
+        [Packet(COMMAND="E", ADDR=0, SIZE=5), Packet(COMMAND="E", ADDR=5, SIZE=5)],
+        [Packet(COMMAND="E", ADDR=0, SIZE=10)]
+    ],
+    [
+        [Packet(COMMAND="E", ADDR=10, SIZE=5), Packet(COMMAND="E", ADDR=10, SIZE=7)],
+        [Packet(COMMAND="E", ADDR=10, SIZE=7)]
+    ],
+    [
+        [Packet(COMMAND="E", ADDR=10, SIZE=5), Packet(COMMAND="E", ADDR=10, SIZE=7), Packet(COMMAND="E", ADDR=12, SIZE=3)],
+        [Packet(COMMAND="E", ADDR=10, SIZE=7)]
+    ],
+
+    # 3. 중첩, 연속 erase merge (총 길이 10 이상)
+    [
+        [Packet(COMMAND="E", ADDR=0, SIZE=7), Packet(COMMAND="E", ADDR=7, SIZE=7), Packet(COMMAND="E", ADDR=14, SIZE=6)],
+        [Packet(COMMAND="E", ADDR=0, SIZE=10), Packet(COMMAND="E", ADDR=10, SIZE=10)]
+    ],
+
+    # 4. erase에 의해 overwrite 되는 write 명령 제거
+    [
+        [Packet(COMMAND="W", ADDR=1, VALUE=0x1), Packet(COMMAND="W", ADDR=3, VALUE=0x3), Packet(COMMAND="W", ADDR=5, VALUE=0x5),
+         Packet(COMMAND="E", ADDR=0, SIZE=10)],
+        [Packet(COMMAND="E", ADDR=0, SIZE=10)]
+    ],
+
+    # 5. erase가 write 보다 먼저 수행되는 경우 wirte 명령 유지
+    [
+        [Packet(COMMAND="E", ADDR=0, SIZE=10),
+        Packet(COMMAND="W", ADDR=1, VALUE=0x1), Packet(COMMAND="W", ADDR=3, VALUE=0x3), Packet(COMMAND="W", ADDR=5, VALUE=0x5)],
+        [Packet(COMMAND="E", ADDR=0, SIZE=10),
+         Packet(COMMAND="W", ADDR=1, VALUE=0x1), Packet(COMMAND="W", ADDR=3, VALUE=0x3), Packet(COMMAND="W", ADDR=5, VALUE=0x5)]
+    ],
+
+    # 6. write로 덮어지는 영역이 2개 이상의 erase 영역을 접합하는 경우
+    [
+        [Packet(COMMAND="E", ADDR=0, SIZE=2), Packet(COMMAND="E", ADDR=3, SIZE=2), Packet(COMMAND="E", ADDR=6, SIZE=2),
+        Packet(COMMAND="W", ADDR=2, VALUE=0x2), Packet(COMMAND="W", ADDR=5, VALUE=0x5)],
+        [Packet(COMMAND="E", ADDR=0, SIZE=8),
+         Packet(COMMAND="W", ADDR=2, VALUE=0x2), Packet(COMMAND="W", ADDR=5, VALUE=0x5)]
+    ],
+])
+def test_buffer_최적화_반환_커맨드_동일_케이스_검증(optimizer, tc, expected_cmd):
+    result = optimizer.calculate(tc)
+    assert result == expected_cmd

--- a/tests/test_discovery_buffer_optimizer.py
+++ b/tests/test_discovery_buffer_optimizer.py
@@ -444,6 +444,14 @@ def test_명령어가_1개이하인경우_최적화하지_않는다(abstract_buf
     # 104. erase 명령이 배열 범위 끝에서 수행되는지 확인
     ([Packet("E", 99, SIZE=1), Packet("E", 98, SIZE=2), Packet("E", 97, SIZE=3),],
      [Packet("E", 97, SIZE=3)]),
+
+    # 105. erase 영역 사이에 write가 빈공간을 두고 있는 경우 연결하면 안됨
+    ([Packet("E", 1, SIZE=3), Packet("W", 4, 0x4), Packet("W", 6, 0x6), Packet("W", 8, 0x8), Packet("E", 9, SIZE=4)],
+     [Packet("E", 1, SIZE=3), Packet("W", 4, 0x4), Packet("W", 6, 0x6), Packet("W", 8, 0x8), Packet("E", 9, SIZE=4)]),
+
+    # 16. 병합 후 slicing (20칸 → 10+10)
+    ([Packet("E", 0, SIZE=7), Packet("E", 7, SIZE=7), Packet("E", 14, SIZE=6),],
+     [Packet("E", 0, SIZE=10), Packet("E", 10, SIZE=10),]),
 ])
 def test_buffer_최적화_반환_커맨드_동일_케이스_검증(abstract_buffer_optimizer, tc, expected_cmd):
     result = abstract_buffer_optimizer.calculate(tc)

--- a/tests/test_discovery_buffer_optimizer.py
+++ b/tests/test_discovery_buffer_optimizer.py
@@ -13,7 +13,7 @@ def abstract_buffer_optimizer():
 
 def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_1(discovery_optimizer):
     tc = [
-        Packet(COMMAND="E", ADDR=0, SIZE=1)
+        Packet("E", 0, 1)
     ]
 
     erase_lst = discovery_optimizer.project_erase(tc)
@@ -33,8 +33,8 @@ def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_1(
 
 def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_2(discovery_optimizer):
     tc = [
-        Packet(COMMAND="E", ADDR=0, SIZE=1),
-        Packet(COMMAND="E", ADDR=0, SIZE=1)
+        Packet("E", 0, 1),
+        Packet("E", 0, 1)
     ]
 
     erase_lst = discovery_optimizer.project_erase(tc)
@@ -54,8 +54,8 @@ def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_2(
 
 def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_3(discovery_optimizer):
     tc = [
-        Packet(COMMAND="E", ADDR=0, SIZE=1),
-        Packet(COMMAND="E", ADDR=0, SIZE=2)
+        Packet("E", 0, 1),
+        Packet("E", 0, 2)
     ]
 
     erase_lst = discovery_optimizer.project_erase(tc)
@@ -75,8 +75,8 @@ def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_3(
 
 def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_4(discovery_optimizer):
     tc = [
-        Packet(COMMAND="E", ADDR=0, SIZE=1),
-        Packet(COMMAND="E", ADDR=3, SIZE=2)
+        Packet("E", 0, 1),
+        Packet("E", 3, 2)
     ]
 
     erase_lst = discovery_optimizer.project_erase(tc)
@@ -96,9 +96,9 @@ def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_4(
 
 def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_5(discovery_optimizer):
     tc = [
-        Packet(COMMAND="E", ADDR=0, SIZE=1),
-        Packet(COMMAND="E", ADDR=4, SIZE=5),
-        Packet(COMMAND="E", ADDR=10, SIZE=5),
+        Packet("E", 0, 1),
+        Packet("E", 4, 5),
+        Packet("E", 10, 5),
     ]
 
     erase_lst = discovery_optimizer.project_erase(tc)
@@ -118,10 +118,10 @@ def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_5(
 
 def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_6(discovery_optimizer):
     tc = [
-        Packet(COMMAND="E", ADDR=0, SIZE=1),
-        Packet(COMMAND="E", ADDR=4, SIZE=5),
-        Packet(COMMAND="E", ADDR=10, SIZE=5),
-        Packet(COMMAND="E", ADDR=12, SIZE=5),
+        Packet("E", 0, 1),
+        Packet("E", 4, 5),
+        Packet("E", 10, 5),
+        Packet("E", 12, 5),
     ]
 
     erase_lst = discovery_optimizer.project_erase(tc)
@@ -141,11 +141,11 @@ def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_6(
 
 def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_7(discovery_optimizer):
     tc = [
-        Packet(COMMAND="E", ADDR=0, SIZE=1),
-        Packet(COMMAND="E", ADDR=4, SIZE=5),
-        Packet(COMMAND="E", ADDR=10, SIZE=5),
-        Packet(COMMAND="E", ADDR=12, SIZE=5),
-        Packet(COMMAND="E", ADDR=95, SIZE=5),
+        Packet("E", 0, 1),
+        Packet("E", 4, 5),
+        Packet("E", 10, 5),
+        Packet("E", 12, 5),
+        Packet("E", 95, 5),
     ]
 
     erase_lst = discovery_optimizer.project_erase(tc)
@@ -165,7 +165,7 @@ def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_7(
 
 def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_1(discovery_optimizer):
     tc = [
-        Packet(COMMAND="W", ADDR=0, VALUE=1),
+        Packet("W", 0, 1),
     ]
 
     erase_lst, _ = discovery_optimizer.project_write(tc)
@@ -184,8 +184,8 @@ def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_1(
 
 def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_2(discovery_optimizer):
     tc = [
-        Packet(COMMAND="W", ADDR=0, VALUE=1),
-        Packet(COMMAND="W", ADDR=0, VALUE=1),
+        Packet("W", 0, 1),
+        Packet("W", 0, 1),
     ]
 
     erase_lst, _ = discovery_optimizer.project_write(tc)
@@ -205,8 +205,8 @@ def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_2(
 
 def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_3(discovery_optimizer):
     tc = [
-        Packet(COMMAND="W", ADDR=0, VALUE=1),
-        Packet(COMMAND="W", ADDR=1, VALUE=1),
+        Packet("W", 0, 1),
+        Packet("W", 1, 1),
     ]
 
     erase_lst, _ = discovery_optimizer.project_write(tc)
@@ -226,9 +226,9 @@ def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_3(
 
 def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_4(discovery_optimizer):
     tc = [
-        Packet(COMMAND="W", ADDR=0, VALUE=1),
-        Packet(COMMAND="W", ADDR=1, VALUE=1),
-        Packet(COMMAND="E", ADDR=1, SIZE=2),
+        Packet("W", 0, 1),
+        Packet("W", 1, 1),
+        Packet("E", 1, 2),
     ]
 
     erase_lst, _ = discovery_optimizer.project_write(tc)
@@ -247,9 +247,9 @@ def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_4(
 
 def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_5(discovery_optimizer):
     tc = [
-        Packet(COMMAND="W", ADDR=0, VALUE=1),
-        Packet(COMMAND="E", ADDR=1, SIZE=2),
-        Packet(COMMAND="W", ADDR=1, VALUE=1),
+        Packet("W", 0, 1),
+        Packet("E", 1, 2),
+        Packet("W", 1, 1),
     ]
 
     erase_lst, _ = discovery_optimizer.project_write(tc)
@@ -269,10 +269,10 @@ def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_5(
 
 def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_6(discovery_optimizer):
     tc = [
-        Packet(COMMAND="W", ADDR=0, VALUE=1),
-        Packet(COMMAND="E", ADDR=1, SIZE=2),
-        Packet(COMMAND="W", ADDR=1, VALUE=1),
-        Packet(COMMAND="E", ADDR=10, SIZE=10),
+        Packet("W", 0, 1),
+        Packet("E", 1, 2),
+        Packet("W", 1, 1),
+        Packet("E", 10, 10),
     ]
 
     erase_lst, _ = discovery_optimizer.project_write(tc)
@@ -291,11 +291,11 @@ def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_6(
 
 def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_7(discovery_optimizer):
     tc = [
-        Packet(COMMAND="W", ADDR=0, VALUE=1),
-        Packet(COMMAND="E", ADDR=1, SIZE=2),
-        Packet(COMMAND="W", ADDR=1, VALUE=1),
-        Packet(COMMAND="E", ADDR=10, SIZE=10),
-        Packet(COMMAND="W", ADDR=10, VALUE=1),
+        Packet("W", 0, 1),
+        Packet("E", 1, 2),
+        Packet("W", 1, 1),
+        Packet("E", 10, 10),
+        Packet("W", 10, 1),
     ]
 
     erase_lst, _ = discovery_optimizer.project_write(tc)
@@ -315,7 +315,7 @@ def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_7(
 
 def test_W_명령값이_0_인경우_E명령으로_대체한다_1(discovery_optimizer):
     tc = [
-        Packet(COMMAND="W", ADDR=3, VALUE=0),
+        Packet("W", 3, 0),
     ]
 
     result = discovery_optimizer.replace_zero_write(tc)
@@ -323,14 +323,14 @@ def test_W_명령값이_0_인경우_E명령으로_대체한다_1(discovery_optim
     assert len(result) == 1
     assert result[0].COMMAND == "E"
     assert result[0].ADDR == 3
-    assert result[0].SIZE == 1
+    assert result[0].VALUE == 1
 
 
 def test_W_명령값이_0_인경우_E명령으로_대체한다_2(discovery_optimizer):
     tc = [
-        Packet(COMMAND="W", ADDR=1, VALUE=1),
-        Packet(COMMAND="W", ADDR=3, VALUE=0),
-        Packet(COMMAND="W", ADDR=2, VALUE=2),
+        Packet("W", 1, 1),
+        Packet("W", 3, 0),
+        Packet("W", 2, 2),
     ]
 
     result = discovery_optimizer.replace_zero_write(tc)
@@ -341,15 +341,15 @@ def test_W_명령값이_0_인경우_E명령으로_대체한다_2(discovery_optim
 
     assert result[1].COMMAND == "E"
     assert result[1].ADDR == 3
-    assert result[1].SIZE == 1
+    assert result[1].VALUE == 1
 
 """
 AbstractBufferOptimizer 구현체에 대한 테스트 코드
 """
 @pytest.mark.parametrize("tc", [
     [],
-    [Packet(COMMAND="W", ADDR=0, VALUE=1)],
-    [Packet(COMMAND="E", ADDR=0, VALUE=1)],
+    [Packet("W", 0, 1)],
+    [Packet("E", 0, 1)],
 ])
 def test_명령어가_1개이하인경우_최적화하지_않는다(abstract_buffer_optimizer, tc):
     result = abstract_buffer_optimizer.calculate(tc)
@@ -359,34 +359,34 @@ def test_명령어가_1개이하인경우_최적화하지_않는다(abstract_buf
 
 @pytest.mark.parametrize("tc, expected_cmd", [
     #1. 중복 erase 제거
-    [[Packet(COMMAND="E", ADDR=0, SIZE=5), Packet(COMMAND="E", ADDR=0, SIZE=5)],
-     [Packet(COMMAND="E", ADDR=0, SIZE=5)]],
-    [[Packet(COMMAND="E", ADDR=10, SIZE=5), Packet(COMMAND="E", ADDR=10, SIZE=2)],
-     [Packet(COMMAND="E", ADDR=10, SIZE=5)]],
+    [[Packet("E", 0, 5), Packet("E", 0, 5)],
+     [Packet("E", 0, 5)]],
+    [[Packet("E", 10, 5), Packet("E", 10, 2)],
+     [Packet("E", 10, 5)]],
 
     # 2. 중첩, 연속 erase merge (총 길이 10 이하)
-    [[Packet(COMMAND="E", ADDR=0, SIZE=5), Packet(COMMAND="E", ADDR=5, SIZE=5)],
-     [Packet(COMMAND="E", ADDR=0, SIZE=10)]],
-    [[Packet(COMMAND="E", ADDR=10, SIZE=5), Packet(COMMAND="E", ADDR=10, SIZE=7)],
-     [Packet(COMMAND="E", ADDR=10, SIZE=7)]],
-    [[Packet(COMMAND="E", ADDR=10, SIZE=5), Packet(COMMAND="E", ADDR=10, SIZE=7), Packet(COMMAND="E", ADDR=12, SIZE=3)],
-     [Packet(COMMAND="E", ADDR=10, SIZE=7)]],
+    [[Packet("E", 0, 5), Packet("E", 5, 5)],
+     [Packet("E", 0, 10)]],
+    [[Packet("E", 10, 5), Packet("E", 10, 7)],
+     [Packet("E", 10, 7)]],
+    [[Packet("E", 10, 5), Packet("E", 10, 7), Packet("E", 12, 3)],
+     [Packet("E", 10, 7)]],
 
     # 3. 중첩, 연속 erase merge (총 길이 10 이상)
-    [[Packet(COMMAND="E", ADDR=0, SIZE=7), Packet(COMMAND="E", ADDR=7, SIZE=7), Packet(COMMAND="E", ADDR=14, SIZE=6)],
-     [Packet(COMMAND="E", ADDR=0, SIZE=10), Packet(COMMAND="E", ADDR=10, SIZE=10)]],
+    [[Packet("E", 0, 7), Packet("E", 7, 7), Packet("E", 14, 6)],
+     [Packet("E", 0, 10), Packet("E", 10, 10)]],
 
     # 4. erase에 의해 overwrite 되는 write 명령 제거
-    [[Packet(COMMAND="W", ADDR=1, VALUE=0x1), Packet(COMMAND="W", ADDR=3, VALUE=0x3), Packet(COMMAND="W", ADDR=5, VALUE=0x5), Packet(COMMAND="E", ADDR=0, SIZE=10)],
-     [Packet(COMMAND="E", ADDR=0, SIZE=10)]],
+    [[Packet("W", 1, VALUE=0x1), Packet("W", 3, VALUE=0x3), Packet("W", 5, VALUE=0x5), Packet("E", 0, 10)],
+     [Packet("E", 0, 10)]],
 
     # 5. erase가 write 보다 먼저 수행되는 경우 write 명령 유지
-    [[Packet(COMMAND="E", ADDR=0, SIZE=10), Packet(COMMAND="W", ADDR=1, VALUE=0x1), Packet(COMMAND="W", ADDR=3, VALUE=0x3), Packet(COMMAND="W", ADDR=5, VALUE=0x5)],
-     [Packet(COMMAND="E", ADDR=0, SIZE=10), Packet(COMMAND="W", ADDR=1, VALUE=0x1), Packet(COMMAND="W", ADDR=3, VALUE=0x3), Packet(COMMAND="W", ADDR=5, VALUE=0x5)]],
+    [[Packet("E", 0, 10), Packet("W", 1, VALUE=0x1), Packet("W", 3, VALUE=0x3), Packet("W", 5, VALUE=0x5)],
+     [Packet("E", 0, 10), Packet("W", 1, VALUE=0x1), Packet("W", 3, VALUE=0x3), Packet("W", 5, VALUE=0x5)]],
 
     # 6. write로 덮어지는 영역이 2개 이상의 erase 영역을 접합하는 경우
-    [[Packet(COMMAND="E", ADDR=0, SIZE=2), Packet(COMMAND="E", ADDR=3, SIZE=2), Packet(COMMAND="E", ADDR=6, SIZE=2), Packet(COMMAND="W", ADDR=2, VALUE=0x2), Packet(COMMAND="W", ADDR=5, VALUE=0x5)],
-     [Packet(COMMAND="E", ADDR=0, SIZE=8), Packet(COMMAND="W", ADDR=2, VALUE=0x2), Packet(COMMAND="W", ADDR=5, VALUE=0x5)]],
+    [[Packet("E", 0, 2), Packet("E", 3, 2), Packet("E", 6, 2), Packet("W", 2, VALUE=0x2), Packet("W", 5, VALUE=0x5)],
+     [Packet("E", 0, 8), Packet("W", 2, VALUE=0x2), Packet("W", 5, VALUE=0x5)]],
 
     # tc from SimpleBufferOptimizer
     # 1. 중복 Write 제거
@@ -398,65 +398,65 @@ def test_명령어가_1개이하인경우_최적화하지_않는다(abstract_buf
      [Packet("W", 5, 0x3)]),
 
     # 3. Erase가 Write 무효화
-    ([Packet("W", 20, 0xAAA), Packet("E", 19, SIZE=2)],
-     [Packet("E", 19, SIZE=2)]),
+    ([Packet("W", 20, 0xAAA), Packet("E", 19, 2)],
+     [Packet("E", 19, 2)]),
 
     # 4. Erase가 Write에 영향 없음
-    ([Packet("W", 20, 0xAAA), Packet("E", 10, SIZE=5)],
-     [Packet("W", 20, 0xAAA), Packet("E", 10, SIZE=5)]),
+    ([Packet("W", 20, 0xAAA), Packet("E", 10, 5)],
+     [Packet("W", 20, 0xAAA), Packet("E", 10, 5)]),
 
     # 5. Erase 병합 (연속 영역)
-    ([Packet("E", 30, SIZE=5), Packet("E", 35, SIZE=3)],
-     [Packet("E", 30, SIZE=8)]),
+    ([Packet("E", 30, 5), Packet("E", 35, 3)],
+     [Packet("E", 30, 8)]),
 
     # 6. Erase 병합 불가 (간격 존재)
-    ([Packet("E", 30, SIZE=3), Packet("E", 40, SIZE=2)],
-     [Packet("E", 30, SIZE=3), Packet("E", 40, SIZE=2)]),
+    ([Packet("E", 30, 3), Packet("E", 40, 2)],
+     [Packet("E", 30, 3), Packet("E", 40, 2)]),
 
     # 7. 병합은 가능하나 size > 10
-    ([Packet("E", 10, SIZE=6), Packet("E", 16, SIZE=6)],
-     [Packet("E", 10, SIZE=6), Packet("E", 16, SIZE=6)]),
+    ([Packet("E", 10, 6), Packet("E", 16, 6)],
+     [Packet("E", 10, 6), Packet("E", 16, 6)]),
 
     # 8. 중복 W 제거 + Erase로 W 제거 + Erase 병합
-    ([Packet("W", 1, 0x111), Packet("W", 1, 0x222), Packet("E", 0, SIZE=2), Packet("E", 2, SIZE=2)],
-     [Packet("E", 0, SIZE=4)]),
+    ([Packet("W", 1, 0x111), Packet("W", 1, 0x222), Packet("E", 0, 2), Packet("E", 2, 2)],
+     [Packet("E", 0, 4)]),
 
     # ✅ 9. Write가 Erase 범위 밖 → 유지 (결과 순서 수정됨)
-    ([Packet("E", 90, SIZE=5), Packet("W", 80, 0x1)],
-     [Packet("E", 90, SIZE=5), Packet("W", 80, 0x1)]),
+    ([Packet("E", 90, 5), Packet("W", 80, 0x1)],
+     [Packet("E", 90, 5), Packet("W", 80, 0x1)]),
 
     # 10. 모든 Write 무효화됨
-    ([Packet("W", 1, 0x1), Packet("W", 1, 0x2), Packet("E", 0, SIZE=5)],
-     [Packet("E", 0, SIZE=5)]),
+    ([Packet("W", 1, 0x1), Packet("W", 1, 0x2), Packet("E", 0, 5)],
+     [Packet("E", 0, 5)]),
 
     # 101. erase 2개를 write 3개가 연결, write/erase 1개 겹침
-    ([Packet("E", 0, SIZE=5), Packet("E", 7, SIZE=2), Packet("W", 5, 0x5), Packet("W", 6, 0x6), Packet("W", 7, 0x7)],
-     [Packet("E", 0, SIZE=9), Packet("W", 5, 0x5), Packet("W", 6, 0x6), Packet("W", 7, 0x7)]),
+    ([Packet("E", 0, 5), Packet("E", 7, 2), Packet("W", 5, 0x5), Packet("W", 6, 0x6), Packet("W", 7, 0x7)],
+     [Packet("E", 0, 9), Packet("W", 5, 0x5), Packet("W", 6, 0x6), Packet("W", 7, 0x7)]),
 
     # 102. erase 2개를 write 3개가 연결, write/erase 겹치지 않음
-    ([Packet("E", 0, SIZE=5), Packet("E", 8, SIZE=2), Packet("W", 5, 0x5), Packet("W", 6, 0x6), Packet("W", 7, 0x7)],
-     [Packet("E", 0, SIZE=10), Packet("W", 5, 0x5), Packet("W", 6, 0x6), Packet("W", 7, 0x7)]),
+    ([Packet("E", 0, 5), Packet("E", 8, 2), Packet("W", 5, 0x5), Packet("W", 6, 0x6), Packet("W", 7, 0x7)],
+     [Packet("E", 0, 10), Packet("W", 5, 0x5), Packet("W", 6, 0x6), Packet("W", 7, 0x7)]),
 
     # 103. erase 2개를 write 3개가 연결하지만 erase 10개 초과로 연결하지 못함
-    ([Packet("E", 0, SIZE=8), Packet("E", 11, SIZE=4), Packet("W", 8, 0x8), Packet("W", 9, 0x9), Packet("W", 10, 0x10)],
-     [Packet("E", 0, SIZE=8), Packet("E", 11, SIZE=4), Packet("W", 8, 0x8), Packet("W", 9, 0x9), Packet("W", 10, 0x10)]),
+    ([Packet("E", 0, 8), Packet("E", 11, 4), Packet("W", 8, 0x8), Packet("W", 9, 0x9), Packet("W", 10, 0x10)],
+     [Packet("E", 0, 8), Packet("E", 11, 4), Packet("W", 8, 0x8), Packet("W", 9, 0x9), Packet("W", 10, 0x10)]),
 
     # 104. erase 명령이 배열 범위 끝에서 수행되는지 확인
-    ([Packet("E", 99, SIZE=1), Packet("E", 98, SIZE=2), Packet("E", 97, SIZE=3),],
-     [Packet("E", 97, SIZE=3)]),
+    ([Packet("E", 99, 1), Packet("E", 98, 2), Packet("E", 97, 3),],
+     [Packet("E", 97, 3)]),
 
     # 105. erase 영역 사이에 write가 빈공간을 두고 있는 경우 연결하면 안됨
-    ([Packet("E", 1, SIZE=3), Packet("W", 4, 0x4), Packet("W", 6, 0x6), Packet("W", 8, 0x8), Packet("E", 9, SIZE=4)],
-     [Packet("E", 1, SIZE=3), Packet("W", 4, 0x4), Packet("W", 6, 0x6), Packet("W", 8, 0x8), Packet("E", 9, SIZE=4)]),
+    ([Packet("E", 1, 3), Packet("W", 4, 0x4), Packet("W", 6, 0x6), Packet("W", 8, 0x8), Packet("E", 9, 4)],
+     [Packet("E", 1, 3), Packet("W", 4, 0x4), Packet("W", 6, 0x6), Packet("W", 8, 0x8), Packet("E", 9, 4)]),
 
     # 16. 병합 후 slicing (20칸 → 10+10)
-    ([Packet("E", 0, SIZE=7), Packet("E", 7, SIZE=7), Packet("E", 14, SIZE=6),],
-     [Packet("E", 0, SIZE=10), Packet("E", 10, SIZE=10),]),
+    ([Packet("E", 0, 7), Packet("E", 7, 7), Packet("E", 14, 6),],
+     [Packet("E", 0, 10), Packet("E", 10, 10),]),
 
     # 106. write bridge로 연결 가능한 write 영역 2개와 erase 최대 길이 초과로 연결 불가능한 erase 1개 조합
     # return case가 여러 가지 일 수 있음
-    ([Packet("E", 0, SIZE=4), Packet("W", 4, 0x4), Packet("W", 10, 0x10), Packet("E", 5, SIZE=5), Packet("E", 11, SIZE=3)],
-     [Packet("E", 0, SIZE=10), Packet("E", 10, SIZE=4), Packet("W", 4, 0x4), Packet("W", 10, 0x10)]),
+    ([Packet("E", 0, 4), Packet("W", 4, 0x4), Packet("W", 10, 0x10), Packet("E", 5, 5), Packet("E", 11, 3)],
+     [Packet("E", 0, 10), Packet("E", 10, 4), Packet("W", 4, 0x4), Packet("W", 10, 0x10)]),
 ])
 def test_buffer_최적화_반환_커맨드_동일_케이스_검증(abstract_buffer_optimizer, tc, expected_cmd):
     result = abstract_buffer_optimizer.calculate(tc)

--- a/tests/test_discovery_buffer_optimizer.py
+++ b/tests/test_discovery_buffer_optimizer.py
@@ -452,6 +452,11 @@ def test_명령어가_1개이하인경우_최적화하지_않는다(abstract_buf
     # 16. 병합 후 slicing (20칸 → 10+10)
     ([Packet("E", 0, SIZE=7), Packet("E", 7, SIZE=7), Packet("E", 14, SIZE=6),],
      [Packet("E", 0, SIZE=10), Packet("E", 10, SIZE=10),]),
+
+    # 106. write bridge로 연결 가능한 write 영역 2개와 erase 최대 길이 초과로 연결 불가능한 erase 1개 조합
+    # return case가 여러 가지 일 수 있음
+    ([Packet("E", 0, SIZE=4), Packet("W", 4, 0x4), Packet("W", 10, 0x10), Packet("E", 5, SIZE=5), Packet("E", 11, SIZE=3)],
+     [Packet("E", 0, SIZE=10), Packet("E", 10, SIZE=4), Packet("W", 4, 0x4), Packet("W", 10, 0x10)]),
 ])
 def test_buffer_최적화_반환_커맨드_동일_케이스_검증(abstract_buffer_optimizer, tc, expected_cmd):
     result = abstract_buffer_optimizer.calculate(tc)

--- a/tests/test_discovery_buffer_optimizer.py
+++ b/tests/test_discovery_buffer_optimizer.py
@@ -3,15 +3,20 @@ import pytest
 from ssd_core.discovery_buffer_optimizer import DiscoveryBufferOptimizer
 from validator import Packet
 
+@pytest.fixture
+def discovery_optimizer():
+    return DiscoveryBufferOptimizer()
 
-def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_1():
-    algo = DiscoveryBufferOptimizer()
+@pytest.fixture
+def abstract_buffer_optimizer():
+    return DiscoveryBufferOptimizer()
 
+def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_1(discovery_optimizer):
     tc = [
         Packet(COMMAND="E", ADDR=0, SIZE=1)
     ]
 
-    erase_lst = algo.project_erase(tc)
+    erase_lst = discovery_optimizer.project_erase(tc)
     assert erase_lst == [
         1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -26,15 +31,13 @@ def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_1(
     ]
 
 
-def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_2():
-    algo = DiscoveryBufferOptimizer()
-
+def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_2(discovery_optimizer):
     tc = [
         Packet(COMMAND="E", ADDR=0, SIZE=1),
         Packet(COMMAND="E", ADDR=0, SIZE=1)
     ]
 
-    erase_lst = algo.project_erase(tc)
+    erase_lst = discovery_optimizer.project_erase(tc)
     assert erase_lst == [
         1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -49,15 +52,13 @@ def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_2(
     ]
 
 
-def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_3():
-    algo = DiscoveryBufferOptimizer()
-
+def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_3(discovery_optimizer):
     tc = [
         Packet(COMMAND="E", ADDR=0, SIZE=1),
         Packet(COMMAND="E", ADDR=0, SIZE=2)
     ]
 
-    erase_lst = algo.project_erase(tc)
+    erase_lst = discovery_optimizer.project_erase(tc)
     assert erase_lst == [
         1, 1, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -72,15 +73,13 @@ def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_3(
     ]
 
 
-def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_4():
-    algo = DiscoveryBufferOptimizer()
-
+def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_4(discovery_optimizer):
     tc = [
         Packet(COMMAND="E", ADDR=0, SIZE=1),
         Packet(COMMAND="E", ADDR=3, SIZE=2)
     ]
 
-    erase_lst = algo.project_erase(tc)
+    erase_lst = discovery_optimizer.project_erase(tc)
     assert erase_lst == [
         1, 0, 0, 1, 1, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -95,16 +94,14 @@ def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_4(
     ]
 
 
-def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_5():
-    algo = DiscoveryBufferOptimizer()
-
+def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_5(discovery_optimizer):
     tc = [
         Packet(COMMAND="E", ADDR=0, SIZE=1),
         Packet(COMMAND="E", ADDR=4, SIZE=5),
         Packet(COMMAND="E", ADDR=10, SIZE=5),
     ]
 
-    erase_lst = algo.project_erase(tc)
+    erase_lst = discovery_optimizer.project_erase(tc)
     assert erase_lst == [
         1, 0, 0, 0, 1, 1, 1, 1, 1, 0,
         1, 1, 1, 1, 1, 0, 0, 0, 0, 0,
@@ -119,9 +116,7 @@ def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_5(
     ]
 
 
-def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_6():
-    algo = DiscoveryBufferOptimizer()
-
+def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_6(discovery_optimizer):
     tc = [
         Packet(COMMAND="E", ADDR=0, SIZE=1),
         Packet(COMMAND="E", ADDR=4, SIZE=5),
@@ -129,7 +124,7 @@ def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_6(
         Packet(COMMAND="E", ADDR=12, SIZE=5),
     ]
 
-    erase_lst = algo.project_erase(tc)
+    erase_lst = discovery_optimizer.project_erase(tc)
     assert erase_lst == [
         1, 0, 0, 0, 1, 1, 1, 1, 1, 0,
         1, 1, 1, 1, 1, 1, 1, 0, 0, 0,
@@ -144,9 +139,7 @@ def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_6(
     ]
 
 
-def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_7():
-    algo = DiscoveryBufferOptimizer()
-
+def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_7(discovery_optimizer):
     tc = [
         Packet(COMMAND="E", ADDR=0, SIZE=1),
         Packet(COMMAND="E", ADDR=4, SIZE=5),
@@ -155,7 +148,7 @@ def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_7(
         Packet(COMMAND="E", ADDR=95, SIZE=5),
     ]
 
-    erase_lst = algo.project_erase(tc)
+    erase_lst = discovery_optimizer.project_erase(tc)
     assert erase_lst == [
         1, 0, 0, 0, 1, 1, 1, 1, 1, 0,
         1, 1, 1, 1, 1, 1, 1, 0, 0, 0,
@@ -170,14 +163,12 @@ def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_7(
     ]
 
 
-def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_1():
-    algo = DiscoveryBufferOptimizer()
-
+def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_1(discovery_optimizer):
     tc = [
         Packet(COMMAND="W", ADDR=0, VALUE=1),
     ]
 
-    erase_lst = algo.project_write(tc)
+    erase_lst, _ = discovery_optimizer.project_write(tc)
     assert erase_lst == [
         1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -191,15 +182,13 @@ def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_1(
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ]
 
-def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_2():
-    algo = DiscoveryBufferOptimizer()
-
+def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_2(discovery_optimizer):
     tc = [
         Packet(COMMAND="W", ADDR=0, VALUE=1),
         Packet(COMMAND="W", ADDR=0, VALUE=1),
     ]
 
-    erase_lst = algo.project_write(tc)
+    erase_lst, _ = discovery_optimizer.project_write(tc)
     assert erase_lst == [
         1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -214,15 +203,13 @@ def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_2(
     ]
 
 
-def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_3():
-    algo = DiscoveryBufferOptimizer()
-
+def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_3(discovery_optimizer):
     tc = [
         Packet(COMMAND="W", ADDR=0, VALUE=1),
         Packet(COMMAND="W", ADDR=1, VALUE=1),
     ]
 
-    erase_lst = algo.project_write(tc)
+    erase_lst, _ = discovery_optimizer.project_write(tc)
     assert erase_lst == [
         1, 1, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -237,16 +224,14 @@ def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_3(
     ]
 
 
-def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_4():
-    algo = DiscoveryBufferOptimizer()
-
+def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_4(discovery_optimizer):
     tc = [
         Packet(COMMAND="W", ADDR=0, VALUE=1),
         Packet(COMMAND="W", ADDR=1, VALUE=1),
         Packet(COMMAND="E", ADDR=1, SIZE=2),
     ]
 
-    erase_lst = algo.project_write(tc)
+    erase_lst, _ = discovery_optimizer.project_write(tc)
     assert erase_lst == [
         1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -260,16 +245,14 @@ def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_4(
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ]
 
-def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_5():
-    algo = DiscoveryBufferOptimizer()
-
+def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_5(discovery_optimizer):
     tc = [
         Packet(COMMAND="W", ADDR=0, VALUE=1),
         Packet(COMMAND="E", ADDR=1, SIZE=2),
         Packet(COMMAND="W", ADDR=1, VALUE=1),
     ]
 
-    erase_lst = algo.project_write(tc)
+    erase_lst, _ = discovery_optimizer.project_write(tc)
     assert erase_lst == [
         1, 1, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -284,9 +267,7 @@ def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_5(
     ]
 
 
-def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_6():
-    algo = DiscoveryBufferOptimizer()
-
+def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_6(discovery_optimizer):
     tc = [
         Packet(COMMAND="W", ADDR=0, VALUE=1),
         Packet(COMMAND="E", ADDR=1, SIZE=2),
@@ -294,7 +275,7 @@ def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_6(
         Packet(COMMAND="E", ADDR=10, SIZE=10),
     ]
 
-    erase_lst = algo.project_write(tc)
+    erase_lst, _ = discovery_optimizer.project_write(tc)
     assert erase_lst == [
         1, 1, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -308,9 +289,7 @@ def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_6(
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ]
 
-def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_7():
-    algo = DiscoveryBufferOptimizer()
-
+def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_7(discovery_optimizer):
     tc = [
         Packet(COMMAND="W", ADDR=0, VALUE=1),
         Packet(COMMAND="E", ADDR=1, SIZE=2),
@@ -319,7 +298,7 @@ def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_7(
         Packet(COMMAND="W", ADDR=10, VALUE=1),
     ]
 
-    erase_lst = algo.project_write(tc)
+    erase_lst, _ = discovery_optimizer.project_write(tc)
     assert erase_lst == [
         1, 1, 0, 0, 0, 0, 0, 0, 0, 0,
         1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -334,14 +313,12 @@ def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_7(
     ]
 
 
-def test_W_명령값이_0_인경우_E명령으로_대체한다_1():
-    algo = DiscoveryBufferOptimizer()
-
+def test_W_명령값이_0_인경우_E명령으로_대체한다_1(discovery_optimizer):
     tc = [
         Packet(COMMAND="W", ADDR=3, VALUE=0),
     ]
 
-    result = algo.replace_zero_write(tc)
+    result = discovery_optimizer.replace_zero_write(tc)
 
     assert len(result) == 1
     assert result[0].COMMAND == "E"
@@ -349,16 +326,14 @@ def test_W_명령값이_0_인경우_E명령으로_대체한다_1():
     assert result[0].SIZE == 1
 
 
-def test_W_명령값이_0_인경우_E명령으로_대체한다_2():
-    algo = DiscoveryBufferOptimizer()
-
+def test_W_명령값이_0_인경우_E명령으로_대체한다_2(discovery_optimizer):
     tc = [
         Packet(COMMAND="W", ADDR=1, VALUE=1),
         Packet(COMMAND="W", ADDR=3, VALUE=0),
         Packet(COMMAND="W", ADDR=2, VALUE=2),
     ]
 
-    result = algo.replace_zero_write(tc)
+    result = discovery_optimizer.replace_zero_write(tc)
 
     assert len(result) == 3
     assert result[0] == tc[0]
@@ -368,13 +343,16 @@ def test_W_명령값이_0_인경우_E명령으로_대체한다_2():
     assert result[1].ADDR == 3
     assert result[1].SIZE == 1
 
+"""
+AbstractBufferOptimizer 구현체에 대한 테스트 코드
+"""
 @pytest.mark.parametrize("tc", [
     [],
     [Packet(COMMAND="W", ADDR=0, VALUE=1)],
     [Packet(COMMAND="E", ADDR=0, VALUE=1)],
 ])
-def test_명령어가_1개이하인경우_최적화하지_않는다(optimizer, tc):
-    result = optimizer.calculate(tc)
+def test_명령어가_1개이하인경우_최적화하지_않는다(abstract_buffer_optimizer, tc):
+    result = abstract_buffer_optimizer.calculate(tc)
 
     assert result == tc
 
@@ -433,6 +411,6 @@ def test_명령어가_1개이하인경우_최적화하지_않는다(optimizer, t
          Packet(COMMAND="W", ADDR=2, VALUE=0x2), Packet(COMMAND="W", ADDR=5, VALUE=0x5)]
     ],
 ])
-def test_buffer_최적화_반환_커맨드_동일_케이스_검증(optimizer, tc, expected_cmd):
-    result = optimizer.calculate(tc)
+def test_buffer_최적화_반환_커맨드_동일_케이스_검증(abstract_buffer_optimizer, tc, expected_cmd):
+    result = abstract_buffer_optimizer.calculate(tc)
     assert result == expected_cmd

--- a/tests/test_discovery_buffer_optimizer.py
+++ b/tests/test_discovery_buffer_optimizer.py
@@ -356,8 +356,8 @@ def test_명령어가_1개이하인경우_최적화하지_않는다(abstract_buf
 
     assert result == tc
 
-
-@pytest.mark.parametrize("tc, expected_cmd", [
+REPEAT_FOR_STRESS = 1
+@pytest.mark.parametrize("tc, expected_cmd", REPEAT_FOR_STRESS * [
     #1. 중복 erase 제거
     [[Packet("E", 0, 5), Packet("E", 0, 5)],
      [Packet("E", 0, 5)]],
@@ -377,16 +377,16 @@ def test_명령어가_1개이하인경우_최적화하지_않는다(abstract_buf
      [Packet("E", 0, 10), Packet("E", 10, 10)]],
 
     # 4. erase에 의해 overwrite 되는 write 명령 제거
-    [[Packet("W", 1, VALUE=0x1), Packet("W", 3, VALUE=0x3), Packet("W", 5, VALUE=0x5), Packet("E", 0, 10)],
+    [[Packet("W", 1, 0x1), Packet("W", 3, 0x3), Packet("W", 5, 0x5), Packet("E", 0, 10)],
      [Packet("E", 0, 10)]],
 
     # 5. erase가 write 보다 먼저 수행되는 경우 write 명령 유지
-    [[Packet("E", 0, 10), Packet("W", 1, VALUE=0x1), Packet("W", 3, VALUE=0x3), Packet("W", 5, VALUE=0x5)],
-     [Packet("E", 0, 10), Packet("W", 1, VALUE=0x1), Packet("W", 3, VALUE=0x3), Packet("W", 5, VALUE=0x5)]],
+    [[Packet("E", 0, 10), Packet("W", 1, 0x1), Packet("W", 3, 0x3), Packet("W", 5, 0x5)],
+     [Packet("E", 0, 10), Packet("W", 1, 0x1), Packet("W", 3, 0x3), Packet("W", 5, 0x5)]],
 
     # 6. write로 덮어지는 영역이 2개 이상의 erase 영역을 접합하는 경우
-    [[Packet("E", 0, 2), Packet("E", 3, 2), Packet("E", 6, 2), Packet("W", 2, VALUE=0x2), Packet("W", 5, VALUE=0x5)],
-     [Packet("E", 0, 8), Packet("W", 2, VALUE=0x2), Packet("W", 5, VALUE=0x5)]],
+    [[Packet("E", 0, 2), Packet("E", 3, 2), Packet("E", 6, 2), Packet("W", 2, 0x2), Packet("W", 5, 0x5)],
+     [Packet("E", 0, 8), Packet("W", 2, 0x2), Packet("W", 5, 0x5)]],
 
     # tc from SimpleBufferOptimizer
     # 1. 중복 Write 제거

--- a/tests/test_discovery_buffer_optimizer.py
+++ b/tests/test_discovery_buffer_optimizer.py
@@ -1,4 +1,334 @@
 import pytest
 
-def test_1():
-    algo =
+from ssd_core.discovery_buffer_optimizer import DiscoveryBufferOptimizer
+from validator import Packet
+
+
+def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_1():
+    algo = DiscoveryBufferOptimizer()
+
+    tc = [
+        Packet(COMMAND="E", ADDR=0, SIZE=1)
+    ]
+
+    erase_lst = algo.project_erase(tc)
+    assert erase_lst == [
+        1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ]
+
+
+def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_2():
+    algo = DiscoveryBufferOptimizer()
+
+    tc = [
+        Packet(COMMAND="E", ADDR=0, SIZE=1),
+        Packet(COMMAND="E", ADDR=0, SIZE=1)
+    ]
+
+    erase_lst = algo.project_erase(tc)
+    assert erase_lst == [
+        1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ]
+
+
+def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_3():
+    algo = DiscoveryBufferOptimizer()
+
+    tc = [
+        Packet(COMMAND="E", ADDR=0, SIZE=1),
+        Packet(COMMAND="E", ADDR=0, SIZE=2)
+    ]
+
+    erase_lst = algo.project_erase(tc)
+    assert erase_lst == [
+        1, 1, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ]
+
+
+def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_4():
+    algo = DiscoveryBufferOptimizer()
+
+    tc = [
+        Packet(COMMAND="E", ADDR=0, SIZE=1),
+        Packet(COMMAND="E", ADDR=3, SIZE=2)
+    ]
+
+    erase_lst = algo.project_erase(tc)
+    assert erase_lst == [
+        1, 0, 0, 1, 1, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ]
+
+
+def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_5():
+    algo = DiscoveryBufferOptimizer()
+
+    tc = [
+        Packet(COMMAND="E", ADDR=0, SIZE=1),
+        Packet(COMMAND="E", ADDR=4, SIZE=5),
+        Packet(COMMAND="E", ADDR=10, SIZE=5),
+    ]
+
+    erase_lst = algo.project_erase(tc)
+    assert erase_lst == [
+        1, 0, 0, 0, 1, 1, 1, 1, 1, 0,
+        1, 1, 1, 1, 1, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ]
+
+
+def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_6():
+    algo = DiscoveryBufferOptimizer()
+
+    tc = [
+        Packet(COMMAND="E", ADDR=0, SIZE=1),
+        Packet(COMMAND="E", ADDR=4, SIZE=5),
+        Packet(COMMAND="E", ADDR=10, SIZE=5),
+        Packet(COMMAND="E", ADDR=12, SIZE=5),
+    ]
+
+    erase_lst = algo.project_erase(tc)
+    assert erase_lst == [
+        1, 0, 0, 0, 1, 1, 1, 1, 1, 0,
+        1, 1, 1, 1, 1, 1, 1, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ]
+
+
+def test_Erase영역에_해당하는_주소를_1로_마킹해서_리턴한다_7():
+    algo = DiscoveryBufferOptimizer()
+
+    tc = [
+        Packet(COMMAND="E", ADDR=0, SIZE=1),
+        Packet(COMMAND="E", ADDR=4, SIZE=5),
+        Packet(COMMAND="E", ADDR=10, SIZE=5),
+        Packet(COMMAND="E", ADDR=12, SIZE=5),
+        Packet(COMMAND="E", ADDR=95, SIZE=5),
+    ]
+
+    erase_lst = algo.project_erase(tc)
+    assert erase_lst == [
+        1, 0, 0, 0, 1, 1, 1, 1, 1, 0,
+        1, 1, 1, 1, 1, 1, 1, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 1, 1, 1, 1, 1,
+    ]
+
+
+def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_1():
+    algo = DiscoveryBufferOptimizer()
+
+    tc = [
+        Packet(COMMAND="W", ADDR=0, VALUE=1),
+    ]
+
+    erase_lst = algo.project_write(tc)
+    assert erase_lst == [
+        1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ]
+
+def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_2():
+    algo = DiscoveryBufferOptimizer()
+
+    tc = [
+        Packet(COMMAND="W", ADDR=0, VALUE=1),
+        Packet(COMMAND="W", ADDR=0, VALUE=1),
+    ]
+
+    erase_lst = algo.project_write(tc)
+    assert erase_lst == [
+        1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ]
+
+
+def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_3():
+    algo = DiscoveryBufferOptimizer()
+
+    tc = [
+        Packet(COMMAND="W", ADDR=0, VALUE=1),
+        Packet(COMMAND="W", ADDR=1, VALUE=1),
+    ]
+
+    erase_lst = algo.project_write(tc)
+    assert erase_lst == [
+        1, 1, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ]
+
+
+def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_4():
+    algo = DiscoveryBufferOptimizer()
+
+    tc = [
+        Packet(COMMAND="W", ADDR=0, VALUE=1),
+        Packet(COMMAND="W", ADDR=1, VALUE=1),
+        Packet(COMMAND="E", ADDR=1, SIZE=2),
+    ]
+
+    erase_lst = algo.project_write(tc)
+    assert erase_lst == [
+        1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ]
+
+def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_5():
+    algo = DiscoveryBufferOptimizer()
+
+    tc = [
+        Packet(COMMAND="W", ADDR=0, VALUE=1),
+        Packet(COMMAND="E", ADDR=1, SIZE=2),
+        Packet(COMMAND="W", ADDR=1, VALUE=1),
+    ]
+
+    erase_lst = algo.project_write(tc)
+    assert erase_lst == [
+        1, 1, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ]
+
+
+def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_6():
+    algo = DiscoveryBufferOptimizer()
+
+    tc = [
+        Packet(COMMAND="W", ADDR=0, VALUE=1),
+        Packet(COMMAND="E", ADDR=1, SIZE=2),
+        Packet(COMMAND="W", ADDR=1, VALUE=1),
+        Packet(COMMAND="E", ADDR=10, SIZE=10),
+    ]
+
+    erase_lst = algo.project_write(tc)
+    assert erase_lst == [
+        1, 1, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ]
+
+def test_Write영역에_해당하는_주소를_1로_마킹해서_리턴한다_7():
+    algo = DiscoveryBufferOptimizer()
+
+    tc = [
+        Packet(COMMAND="W", ADDR=0, VALUE=1),
+        Packet(COMMAND="E", ADDR=1, SIZE=2),
+        Packet(COMMAND="W", ADDR=1, VALUE=1),
+        Packet(COMMAND="E", ADDR=10, SIZE=10),
+        Packet(COMMAND="W", ADDR=10, VALUE=1),
+    ]
+
+    erase_lst = algo.project_write(tc)
+    assert erase_lst == [
+        1, 1, 0, 0, 0, 0, 0, 0, 0, 0,
+        1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ]

--- a/tests/test_discovery_buffer_optimizer.py
+++ b/tests/test_discovery_buffer_optimizer.py
@@ -1,0 +1,4 @@
+import pytest
+
+def test_1():
+    algo =


### PR DESCRIPTION
## 📝 작업 요약

- buffer에 입력된 5개의 명령을 최적화 하기 위한 `AbstractBufferOptimizer`의 구현체 `DiscoveryBufferOptimizer` 입니다.
- `DiscoveryBufferOptimizer.calculate()`는 `list[Packet]` 데이터를 입력받고, 최적화 한 후 `list[Packet]` 형태로 반환합니다.
``` python
    # 사용 예시
    original_buffer_cmd: list[Packet] = ...
    optimizer = DiscoveryBufferOptimizer()
    optimized_buffer_cmd: list[Packet] = optimizer.calculate(original_buffer_cmd)
```
- 최적화 수행 전략은 아래와 같습니다.
``` text
- buffer에 의해 수행되는 write/erase 최종 누적 결과를 만든다. (mask 생성) 
- 이 과정에서 동일 위치에 중복 수행되는 cmd는 합져지고 최종 항목만 남게 된다. (ingore command)
- 최종 누적 결과를 최소 명령수로 복원하기 위한 cmd를 생성한다. (merge erase)
```
- 최적화 상세 과정은 아래와 같습니다.
``` text
- 전처리
  - buffer 개수가 0 또는 1인 경우 최적화 하지 않는다.
  - 0으로 write하는 cmd는 erase 명령으로 교체한다. (erase가 merge 가능하여 최적화에 유리)

- 최적화
  - 최종 erase 영역을 하나의 리스트에 누적한다.
  - 최종 write 영역을 하나의 리스트에 누적한다.
  - 최종 결과에 write 되는 항목은 무조건 수행 해야 하므로 이 시점에서 write cmd는 확정된다.
  - write cmd에 의해 덮어써지는 영역은 erase를 수행해도 되고 안해도 되는 영역이다. 필요하면 erase 영역에서 2개의 명령을 연결하기 위한 bridge로 사용해도 된다.
  - write cmd에 의해 덮어써지는 영역을 선택/미선택 하도록 조합을 생성하여, erase 영역을 생성하기 위한 최소 erase 명령 수를 찾는다. (brute-force)

- 결과 판정
  - 찾은 최적화 명령 수가 기존 입력 수와 같거나 크다면 기존 명령 셋을 반환
  - 찾은 최적화 명령 수가 기존 입력 수 보다 더 적다면 최적화 명령 셋 반환
```
---

## ✅ PR 체크리스트

### 🔍 코드 및 테스트 확인
- [x] 코드가 정상적으로 동작함
- [x] 필요한 테스트를 추가했고 기존 테스트를 통과함
- [x] 관련 문서를 업데이트함 (필요한 경우)
- [ ] 리뷰어가 이해할 수 있도록 설명을 충분히 작성함

### 📦 PR 운영 규칙
- [x] 커밋 메시지와 브랜치 이름 규칙을 따름
- [ ] 2명 이상에게 Approve를 받음
- [ ] Merge는 PR 작성자가 직접 수행함
- [ ] Merge 후 PR을 Close하고 브랜치를 삭제함

---

## 📎 관련 이슈

- 관련된 이슈 번호 또는 링크 (예: `#2`)

---

## 💬 참고 사항 (선택)

- 리뷰어에게 전달할 추가 설명이나 요청 사항이 있다면 작성해주세요.
