### PR TITLE
[refactor] abstract_ssd_driver 인자값의 불일치 발생 해결

### DIFF
--- a/command_core/shell_commands/write_command.py
+++ b/command_core/shell_commands/write_command.py
@@ -3,7 +3,7 @@ from command_core.base_command import BaseCommand
 from command_core.exceptions import InvalidLBAError
 
 class WriteCommand(BaseCommand):
-    def __init__(self, ssd: AbstractSSDDriver, lba: int, value: str):
+    def __init__(self, ssd: AbstractSSDDriver, lba: int, value: int):
         self._ssd = ssd
         self._lba = lba
         self._value = value

--- a/shell_core/abstract_ssd_driver.py
+++ b/shell_core/abstract_ssd_driver.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 
 class AbstractSSDDriver(ABC):
     @abstractmethod
-    def write(self, address: int, data: str) -> None:
+    def write(self, address: int, data: int) -> None:
         pass
 
     @abstractmethod


### PR DESCRIPTION

## 📝 작업 요약

변경한 내용을 간단히 bullet point로 작성해주세요 (무엇을, 왜 변경했는지 중심으로).

- write 기능을 위한 driver 의 추상클래스에서는 인자를 str 로 받으나, 구현체에서는 int 로 받도록 되어있어
- 기능 구현에서도 섞여 사용하던바, 실제로는 duck typing으로 동작하던 부분을 수정

---

## ✅ PR 체크리스트

### 🔍 코드 및 테스트 확인
- [ ] 코드가 정상적으로 동작함
- [ ] 필요한 테스트를 추가했고 기존 테스트를 통과함
- [ ] 관련 문서를 업데이트함 (필요한 경우)
- [ ] 리뷰어가 이해할 수 있도록 설명을 충분히 작성함

### 📦 PR 운영 규칙
- [ ] 커밋 메시지와 브랜치 이름 규칙을 따름
- [ ] 2명 이상에게 Approve를 받음
- [ ] Merge는 PR 작성자가 직접 수행함
- [ ] Merge 후 PR을 Close하고 브랜치를 삭제함

---

## 📎 관련 이슈

- 관련된 이슈 번호 또는 링크 (예: `#2`)

---

## 💬 참고 사항 (선택)

- 리뷰어에게 전달할 추가 설명이나 요청 사항이 있다면 작성해주세요.
