### PR TITLE
[fix] discovery optimizer 버그 수정

### DIFF
--- a/ssd_core/optimizer/discovery_buffer_optimizer.py
+++ b/ssd_core/optimizer/discovery_buffer_optimizer.py
@@ -73,6 +73,15 @@ class DiscoveryBufferOptimizer(AbstractBufferOptimizer):
                             counting = True
                             counting_cnt = 1
                             erase_cmd_new = Packet("E", i)
+
+                            # 99에서 ERASE 시작하고 바로 끝나는 케이스
+                            if i == MAX_LBA_ADDRESS - 1:
+                                current_erase_cmd_cnt += 1
+                                erase_cmd_new.OP2 = counting_cnt    # 카운팅 횟수를 증가시키지 않는다. 이미 위에서 하나가 카운팅 됨
+                                current_erase_cmd_lst.append(erase_cmd_new)
+                                erase_cmd_new = None
+                                counting = False
+                                counting_cnt = 0
                         else:
                             if counting_cnt == 9:
                                 current_erase_cmd_cnt += 1


### PR DESCRIPTION
## 📝 작업 요약

변경한 내용을 간단히 bullet point로 작성해주세요 (무엇을, 왜 변경했는지 중심으로).

- erase 명령어가 마지막 메모리 범위에서 시작하고 끝나는 경우 명령어 생성하지 않는 문제 수정
- 수정 후 테스트 케이스 패스 확인
![image](https://github.com/user-attachments/assets/0d7406ad-14b7-456e-a15d-f112fbaf3495)

---

## ✅ PR 체크리스트

### 🔍 코드 및 테스트 확인
- [ ] 코드가 정상적으로 동작함
- [ ] 필요한 테스트를 추가했고 기존 테스트를 통과함
- [ ] 관련 문서를 업데이트함 (필요한 경우)
- [ ] 리뷰어가 이해할 수 있도록 설명을 충분히 작성함

### 📦 PR 운영 규칙
- [ ] 커밋 메시지와 브랜치 이름 규칙을 따름
- [ ] 2명 이상에게 Approve를 받음
- [ ] Merge는 PR 작성자가 직접 수행함
- [ ] Merge 후 PR을 Close하고 브랜치를 삭제함

---

## 📎 관련 이슈

- 관련된 이슈 번호 또는 링크 (예: `#2`)

---

## 💬 참고 사항 (선택)

- 리뷰어에게 전달할 추가 설명이나 요청 사항이 있다면 작성해주세요.
